### PR TITLE
feat: add merge option in mint command

### DIFF
--- a/packages/cli/src/commands/mint/mint.command.ts
+++ b/packages/cli/src/commands/mint/mint.command.ts
@@ -28,6 +28,7 @@ import { calcTotalAmount, sendToken } from '../send/ft';
 import { pickLargeFeeUtxo } from '../send/pick';
 interface MintCommandOptions extends BoardcastCommandOptions {
   id: string;
+  merge: boolean;
   new?: number;
 }
 
@@ -84,7 +85,9 @@ export class MintCommand extends BoardcastCommand {
         const MAX_RETRY_COUNT = 10;
 
         for (let index = 0; index < MAX_RETRY_COUNT; index++) {
-          await this.merge(token, address);
+          if (options.merge) {
+            await this.merge(token, address);
+          }
           const feeRate = await this.getFeeRate();
           const feeUtxos = await this.getFeeUTXOs(address);
           if (feeUtxos.length === 0) {
@@ -262,6 +265,15 @@ export class MintCommand extends BoardcastCommand {
   })
   parseId(val: string): string {
     return val;
+  }
+  @Option({
+    flags: '-m, --merge [merge]',
+    defaultValue: false,
+    description: 'merge token utxos when mint',
+  })
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  parseMerge(val: string): boolean {
+    return true;
   }
 
   async getFeeUTXOs(address: btc.Address) {


### PR DESCRIPTION
Auto merge was redundant before mint, and now merge consumption is too high with high gas, an optional merge option can be added for mint command